### PR TITLE
Pass ... from inf_mr() to rmarkdown::render()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## BUG FIXES
 
 - Pinned the remark.js version to v0.14 until upstream support for the latest release is available
-- Fixed bug with parameterized reports and `infinite_moon_reader()` where `rmarkdown::render()` would throw an error about `params` being in the environment, due to the `params` argument being defined in the calling scope ( `infinite_moon_reader()` ). (thanks @mstr3336, #253)
+
+- `infinite_moon_reader()` now accepts additional arguments via `...` that are passed to `rmarkdown::render()`. This improves the addition of the `params` argument in `infinite_moon_reader()` in version 0.14 and allows users to over-ride parameters defined in the top-level YAML in the slides at run time. It also lets users set rendering options, such as `quiet = TRUE` or setting `output_file`. (thanks @mstr3336, @gadenbuie, #253)
 
 ## MINOR CHANGES
 

--- a/R/render.R
+++ b/R/render.R
@@ -210,7 +210,7 @@ tsukuyomi = function(...) moon_reader(...)
 #' @param moon The input Rmd file path (if missing and in RStudio, the current
 #'   active document is used).
 #' @param cast_from The root directory of the server.
-#' @param params Passed to \code{rmarkdown::\link[rmarkdown]{render}()}.
+#' @param ... Passed to \code{rmarkdown::\link[rmarkdown]{render}()}.
 #' @references \url{http://naruto.wikia.com/wiki/Infinite_Tsukuyomi}
 #' @note This function is not really tied to the output format
 #'   \code{\link{moon_reader}()}. You can use it to serve any single-HTML-file R
@@ -218,9 +218,7 @@ tsukuyomi = function(...) moon_reader(...)
 #' @seealso \code{servr::\link{httw}}
 #' @export
 #' @rdname inf_mr
-infinite_moon_reader = function(moon, cast_from = '.', params = NULL) {
-  parameters <- params
-  rm(params)
+infinite_moon_reader = function(moon, cast_from = '.', ...) {
   # when this function is called via the RStudio addin, use the dir of the
   # current active document
   if (missing(moon) && requireNamespace('rstudioapi', quietly = TRUE)) {
@@ -233,9 +231,10 @@ infinite_moon_reader = function(moon, cast_from = '.', params = NULL) {
     )
   }
   moon = normalize_path(moon)
-  rebuild = function() {
-    rmarkdown::render(moon, envir = parent.frame(2), params = parameters)
-  }
+  dots = list(...)
+  dots$envir = parent.frame()
+  dots$input = moon
+  rebuild = function() do.call(rmarkdown::render, dots)
   html = NULL
   # rebuild if moon or any dependencies (CSS/JS/images) have been updated
   build = local({

--- a/man/inf_mr.Rd
+++ b/man/inf_mr.Rd
@@ -5,9 +5,9 @@
 \alias{inf_mr}
 \title{Serve and live reload slides}
 \usage{
-infinite_moon_reader(moon, cast_from = ".", params = NULL)
+infinite_moon_reader(moon, cast_from = ".", ...)
 
-inf_mr(moon, cast_from = ".", params = NULL)
+inf_mr(moon, cast_from = ".", ...)
 }
 \arguments{
 \item{moon}{The input Rmd file path (if missing and in RStudio, the current
@@ -15,7 +15,7 @@ active document is used).}
 
 \item{cast_from}{The root directory of the server.}
 
-\item{params}{Passed to \code{rmarkdown::\link[rmarkdown]{render}()}.}
+\item{...}{Passed to \code{rmarkdown::\link[rmarkdown]{render}()}.}
 }
 \description{
 Use the \pkg{servr} package to serve and reload slides on change.

--- a/tests/testit/parameterized.Rmd
+++ b/tests/testit/parameterized.Rmd
@@ -1,0 +1,18 @@
+---
+title: "Issue #253"
+subtitle: "https://github.com/yihui/xaringan/issues/253"
+params:
+  foo: oof
+  bar: rab
+  baz: zab
+output:
+  xaringan::moon_reader:
+    lib_dir: libs
+    seal: false
+---
+
+```{r display, echo=FALSE, results="asis"}
+for (nm in names(params)) {
+  cat("\n\nparams$", nm, " = ", params[[nm]], sep = "")
+}
+```

--- a/tests/testit/test-render.R
+++ b/tests/testit/test-render.R
@@ -1,0 +1,41 @@
+library(testit)
+
+tmpin = tempfile(fileext = ".Rmd")
+file.copy("parameterized.Rmd", tmpin)
+tmpout = tempfile(fileext = ".html")
+tmpout_file = basename(tmpout)
+
+options(servr.daemon = TRUE)
+s = xaringan::inf_mr(tmpin,
+                     cast_from = dirname(tmpout),
+                     output_file = tmpout_file,
+                     quiet = TRUE)
+s$stop_server()
+params_top_level = readLines(tmpout)
+
+count_matches = function(pattern, text) sum(grepl(pattern, text, fixed = TRUE))
+
+assert('parameterized slides uses top-level `params` in YAML', {
+  (count_matches("params$foo = oof", params_top_level) %==% 1L)
+  (count_matches("params$bar = rab", params_top_level) %==% 1L)
+  (count_matches("params$baz = zab", params_top_level) %==% 1L)
+})
+
+s = xaringan::inf_mr(tmpin,
+                     cast_from = dirname(tmpout),
+                     params = list(foo = "hello", bar = "world"),
+                     output_file = tmpout_file,
+                     quiet = TRUE)
+s$stop_server()
+params_top_level = readLines(tmpout)
+
+assert('inf_mr(...) overrides `params` in YAML', {
+  (count_matches("params$foo = oof", params_top_level) %==% 0L)
+  (count_matches("params$foo = hello", params_top_level) %==% 1L)
+  (count_matches("params$bar = rab", params_top_level) %==% 0L)
+  (count_matches("params$bar = world", params_top_level) %==% 1L)
+})
+
+assert('inf_mr(...) params falls back to top-level `params` in YAML', {
+  (count_matches("params$baz = zab", params_top_level) %==% 1L)
+})


### PR DESCRIPTION
Instead of reassigning `params`, we can pass `...` from `infinite_moon_reader()` to `rmarkdown::render()`.